### PR TITLE
Update Task Generation Logic 

### DIFF
--- a/lib/EcsSupport.ts
+++ b/lib/EcsSupport.ts
@@ -28,13 +28,15 @@ export function ecsSupport(): ExtensionPack {
         requiredConfigurationValues: [
             "sdm.aws.ecs.launch_type",
             "sdm.aws.ecs.cluster",
-            "sdm.aws.accessKey",
-            "sdm.aws.secretKey",
             {path: "sdm.aws.ecs.desiredCount", type: ConfigurationValueType.Number},
+            {path: "sdm.aws.ecs.taskDefaults.cpu", type: ConfigurationValueType.Number},
+            {path: "sdm.aws.ecs.taskDefaults.memory", type: ConfigurationValueType.Number},
+            "sdm.aws.ecs.taskDefaults.networkMode",
 
             /** -> Add these once supported (https://github.com/atomist/sdm/issues/580)
              * {path: "sdm.aws.ecs.networkConfiguration", type: ConfigurationValueType.Object},
              * {path: "sdm.aws.ecs.roleDetail", type: ConfigurationVaule.Object},
+             * {path: "sdm.aws.ecs.taskDefaults.requiredCompatibilities", type: ConfigurationValue.Array},
              */
         ],
         configure: sdm => {

--- a/lib/deploy/ecsApi.ts
+++ b/lib/deploy/ecsApi.ts
@@ -17,10 +17,10 @@
 import { logger } from "@atomist/automation-client";
 import {
     DeployableArtifact,
+    doWithProject,
     ExecuteGoal,
     ExecuteGoalResult,
     GoalDetails,
-    GoalInvocation,
 } from "@atomist/sdm";
 import _ = require("lodash");
 import {
@@ -32,7 +32,7 @@ import {
 // Execute an ECS deploy
 //  *IF there is a task partion task definition, inject
 export function executeEcsDeploy(registration: EcsDeployRegistration): ExecuteGoal {
-    return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
+    return doWithProject(async goalInvocation => {
         const {goalEvent, credentials, id, progressLog, configuration} = goalInvocation;
 
         // Validate image goal is present
@@ -89,5 +89,5 @@ export function executeEcsDeploy(registration: EcsDeployRegistration): ExecuteGo
         }));
 
         return _.head(results);
-    };
+    });
 }

--- a/lib/goals/EcsDeploy.ts
+++ b/lib/goals/EcsDeploy.ts
@@ -55,6 +55,13 @@ const EcsGoalDefinition: GoalDefinition = {
     canceledDescription: "Deployment to ECS cancelled",
 };
 
+export interface ECSTaskDefaults {
+   cpu: number;
+   memory: number;
+   requiredCompatibilities: ECS.Compatibility[];
+   networkMode: ECS.NetworkMode;
+}
+
 export interface EcsDeployRegistration extends Partial<ImplementationRegistration> {
     serviceRequest?: Partial<ECS.Types.CreateServiceRequest>;
     taskDefinition?: ECS.Types.RegisterTaskDefinitionRequest;
@@ -62,6 +69,7 @@ export interface EcsDeployRegistration extends Partial<ImplementationRegistratio
     region: string;
     roleDetail?: STS.AssumeRoleRequest;
     credentialLookup?: AWSCredentialLookup;
+    taskDefaults?: ECSTaskDefaults;
 }
 
 // tslint:disable-next-line:max-line-length
@@ -270,7 +278,7 @@ export class EcsDeployer implements Deployer<EcsDeploymentInfo & EcsDeployRegist
                            ti: EcsDeploymentInfo,
                            credentials: ProjectOperationCredentials): Promise<EcsDeployment[]> {
 
-        return this.projectLoader.doWithProject({credentials, id, readOnly: true}, async project => {
+        return this.projectLoader.doWithProject({credentials, id, readOnly: true}, async () => {
             logger.warn("Find Deployments is not implemented in ecsDeployer");
             return [];
         });

--- a/lib/support/ecsDataCallback.ts
+++ b/lib/support/ecsDataCallback.ts
@@ -176,7 +176,7 @@ export async function getFinalTaskDefinition(
                 const d = await p.getFile("Dockerfile");
                 dockerFile = await d.getContent();
             } else {
-                reject("No task definition present and no dockerfile found!");
+                reject(new Error("No task definition present and no dockerfile found!"));
             }
 
             // Get Docker commands out
@@ -186,9 +186,9 @@ export async function getFinalTaskDefinition(
             const exposeCommands = commands.filter((c: any) => c.name === "EXPOSE");
 
             if (exposeCommands.length !== 1 && !inProjectTaskDef) {
-                reject(`Unable to determine port for container. Dockerfile in project ` +
+                reject(new Error(`Unable to determine port for container. Dockerfile in project ` +
                     `'${sdmGoal.repo.owner}/${sdmGoal.repo.name}' is missing an EXPOSE instruction or has more then 1.` +
-                    exposeCommands.map((c: any) => c.args).join(", "));
+                    exposeCommands.map((c: any) => c.args).join(", ")));
             } else {
                 newTaskDef.family = imageString;
 

--- a/lib/support/ecsDataCallback.ts
+++ b/lib/support/ecsDataCallback.ts
@@ -28,7 +28,8 @@ import * as path from "path";
 import { createEcsSession } from "../EcsSupport";
 import {
     EcsDeploy,
-    EcsDeployRegistration, ECSTaskDefaults,
+    EcsDeployRegistration,
+    ECSTaskDefaults,
 } from "../goals/EcsDeploy";
 import { createValidServiceRequest } from "./ecsServiceRequest";
 import {

--- a/lib/support/ecsDataCallback.ts
+++ b/lib/support/ecsDataCallback.ts
@@ -170,67 +170,76 @@ export async function getFinalTaskDefinition(
             // .atomist/task-definition.json
             const inProjectTaskDef = await readEcsTaskSpec(p, "task-definition.json");
 
-            // If our registration doesn't include a task definition - generate a generic one
-            if (!registration.taskDefinition && inProjectTaskDef === undefined) {
-                let dockerFile;
-                if (p.hasFile("Dockerfile")) {
-                            const d = await p.getFile("Dockerfile");
-                            dockerFile = await d.getContent();
-                } else {
-                    reject("No task definition present and no dockerfile found!");
-                }
+            // Build 'standard' task def from details
+            let dockerFile;
+            if (p.hasFile("Dockerfile")) {
+                const d = await p.getFile("Dockerfile");
+                dockerFile = await d.getContent();
+            } else {
+                reject("No task definition present and no dockerfile found!");
+            }
 
-                // Get Docker commands out
-                const parser = require("docker-file-parser");
-                const options = { includeComments: false };
-                const commands = parser.parse(dockerFile, options);
-                const exposeCommands = commands.filter((c: any) => c.name === "EXPOSE");
+            // Get Docker commands out
+            const parser = require("docker-file-parser");
+            const options = { includeComments: false };
+            const commands = parser.parse(dockerFile, options);
+            const exposeCommands = commands.filter((c: any) => c.name === "EXPOSE");
 
-                if (exposeCommands.length !== 1) {
-                    reject(`Unable to determine port for default ingress. Dockerfile in project ` +
-                        `'${sdmGoal.repo.owner}/${sdmGoal.repo.name}' has more then one EXPOSE instruction: ` +
-                        exposeCommands.map((c: any) => c.args).join(", "));
-                } else {
-                    newTaskDef.family = imageString;
-                    // TODO: Expose the defaults below in client.config.json
-                    newTaskDef.requiresCompatibilities = [ "FARGATE"];
-                    newTaskDef.networkMode = "awsvpc";
-                    newTaskDef.cpu = "256",
-                    newTaskDef.memory = "512",
+            if (exposeCommands.length !== 1 && !inProjectTaskDef) {
+                reject(`Unable to determine port for container. Dockerfile in project ` +
+                    `'${sdmGoal.repo.owner}/${sdmGoal.repo.name}' is missing an EXPOSE instruction or has more then 1.` +
+                    exposeCommands.map((c: any) => c.args).join(", "));
+            } else {
+                newTaskDef.family = imageString;
 
-                    newTaskDef.containerDefinitions = [
-                        {
-                            name: imageString,
-                            healthCheck: {
-                                command: [
-                                    "CMD-SHELL",
-                                    `wget -O /dev/null http://localhost:${exposeCommands[0].args[0]} || exit 1`,
-                                ],
-                                startPeriod: 30,
-                            },
-                            image: sdmGoal.push.after.image.imageName,
-                            portMappings: [{
-                                containerPort: parseInt(exposeCommands[0].args[0], 10),
-                                hostPort: parseInt(exposeCommands[0].args[0], 10),
-                            }],
+                // TODO: Expose the defaults below in client.config.json
+                newTaskDef.requiresCompatibilities = [ "FARGATE"];
+                newTaskDef.networkMode = "awsvpc";
+                newTaskDef.cpu = "256",
+                newTaskDef.memory = "512",
+                newTaskDef.containerDefinitions = [
+                    {
+                        name: imageString,
+                        healthCheck: {
+                            command: [
+                                "CMD-SHELL",
+                                `wget -O /dev/null http://localhost${exposeCommands.length > 0 ? ":" + exposeCommands[0].args[0] : ""} || exit 1`,
+                            ],
+                            startPeriod: 30,
                         },
-                    ];
-                }
+                        image: sdmGoal.push.after.image.imageName,
+                        // If there are expose commands in the dockerfile, convert those to port mappings
+                        portMappings: exposeCommands.length > 0 ? [{
+                            containerPort: parseInt(exposeCommands[0].args[0], 10),
+                            hostPort: parseInt(exposeCommands[0].args[0], 10),
+                        }] : [],
+                    },
+                ];
+            }
+
+            // If our registration doesn't include a task definition and there isn't a definition in the project, use the generated one
+            if (!registration.taskDefinition && inProjectTaskDef === undefined) {
                 resolve(newTaskDef);
             } else {
-
+                // If there is a in-project task definition merge it with the built-in one
+                //  We merge b/c the taskDefinitions can be the complete definition or just a patch
                 if (inProjectTaskDef !== undefined) {
-                    // Merge in project config onto black definition
+                    // Merge in project config onto blank definition
                     newTaskDef = {...newTaskDef, ...inProjectTaskDef};
                 } else {
+                    // Final fallback, look for taskDefinition on the registration
                     newTaskDef = registration.taskDefinition;
                 }
 
+                // Within the task definition, search all container defs and for the one that matches this Image (from the goal) update to version
+                // we just built
                 newTaskDef.containerDefinitions.forEach( k => {
                     if (imageString === k.name) {
                         k.image = sdmGoal.push.after.image.imageName;
                     }
+
                     // TODO: Expose the defaults below in client.config.json
+                    // If we detect that the memory and cpu values are missing, inject them (required in Fargate)
                     k.memory = k.hasOwnProperty("memory") && k.memory ? k.memory : 512;
                     k.cpu = k.hasOwnProperty("cpu") && k.cpu ? k.cpu : 256;
                 });

--- a/test/support/ecsDataCallback.test.ts
+++ b/test/support/ecsDataCallback.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/support/ecsDataCallback.test.ts
+++ b/test/support/ecsDataCallback.test.ts
@@ -108,6 +108,39 @@ const getDummySdmEvent = (): SdmGoalEvent => {
 };
 
 describe("getFinalTaskDefinition", () => {
+    before(() => {
+        (global as any).__runningAutomationClient = {
+            configuration: {
+                sdm: {
+                    aws: {
+                        ecs: {
+                            launch_type: "FARGATE",
+                            cluster: "tutorial",
+                            desiredCount: 3,
+                            networkConfiguration: {
+                                awsvpcConfiguration: {
+                                    subnets: ["subnet-02ddf34bfe7f6c19a", "subnet-0c5bfb43a631bee45"],
+                                    securityGroups: ["sg-0959d9866b23698f2"],
+                                    assignPublicIp: "ENABLED",
+                                },
+                            },
+                            taskDefaults: {
+                                cpu: 256,
+                                memory: 512,
+                                requiredCompatibilities: ["FARGATE"],
+                                networkMode: "awsvpc",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+    });
+
+    after(() => {
+        delete (global as any).__runningAutomationClient;
+    });
+
     describe("create final task definition from local project and default config", () => {
         it("should succeed", async () => {
             const dummySdmEvent: SdmGoalEvent = getDummySdmEvent();

--- a/test/support/ecsDataCallback.test.ts
+++ b/test/support/ecsDataCallback.test.ts
@@ -156,7 +156,7 @@ describe("getFinalTaskDefinition", () => {
             .then()
             .catch(e => {
                 /* tslint:disable:max-line-length */
-                assert(e === "Unable to determine port for container. Dockerfile in project 'fakeowner/fakerepo' is missing an EXPOSE instruction or has more then 1.");
+                assert(e.message === "Unable to determine port for container. Dockerfile in project 'fakeowner/fakerepo' is missing an EXPOSE instruction or has more then 1.");
             });
         });
     });

--- a/test/support/ecsServiceRequest.test.ts
+++ b/test/support/ecsServiceRequest.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/support/ecsServiceRequest.test.ts
+++ b/test/support/ecsServiceRequest.test.ts
@@ -84,6 +84,12 @@ describe("createValidServiceRequest", () => {
                                         assignPublicIp: "ENABLED",
                                     },
                                 },
+                                taskDefaults: {
+                                    cpu: 256,
+                                    memory: 1024,
+                                    requiredCompatibilities: ["FARGATE"],
+                                    networkMode: "awsvpc",
+                                },
                             },
                         },
                     },


### PR DESCRIPTION
Previously if a simple patch was supplied it would override the entire
task definition.  In this update the 'default' spec is always generated
and then merged with the in project spec (the latter always wins in
conflict)